### PR TITLE
Switch from HttpPlatformHandler to AspNetCoreModule.

### DIFF
--- a/test/ServerComparison.FunctionalTests/Http.config
+++ b/test/ServerComparison.FunctionalTests/Http.config
@@ -118,7 +118,7 @@
             </sectionGroup>
             <section name="applicationInitialization" allowDefinition="MachineToApplication" overrideModeDefault="Allow" />
             <section name="webSocket" overrideModeDefault="Deny" />
-            <section name="httpPlatform" overrideModeDefault="Allow" />
+            <section name="aspNetCore" overrideModeDefault="Allow" />
         </sectionGroup>
     </configSections>
 
@@ -253,7 +253,7 @@
             <add name="ManagedEngine64" image="%windir%\Microsoft.NET\Framework64\v2.0.50727\webengine.dll" preCondition="integratedMode,runtimeVersionv2.0,bitness64" />
             <add name="ManagedEngineV4.0_32bit" image="%windir%\Microsoft.NET\Framework\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness32" />
             <add name="ManagedEngineV4.0_64bit" image="%windir%\Microsoft.NET\Framework64\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness64" />
-            <add name="httpPlatformHandler" image="%SystemRoot%\System32\inetsrv\httpPlatformHandler.dll" />
+            <add name="AspNetCoreModule" image="%SystemRoot%\System32\inetsrv\aspnetcore.dll" />
         </globalModules>
 
         <httpCompression directory="%TEMP%\iisexpress\IIS Temporary Compressed Files">
@@ -928,7 +928,7 @@
                 <add name="UrlRoutingModule-4.0" type="System.Web.Routing.UrlRoutingModule" preCondition="managedHandler,runtimeVersionv4.0" />
                 <add name="ScriptModule-4.0" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
                 <add name="ServiceModel" type="System.ServiceModel.Activation.HttpModule, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="managedHandler,runtimeVersionv2.0" />
-                <add name="httpPlatformHandler" />
+                <add name="AspNetCoreModule" />
             </modules>
             <handlers accessPolicy="Read, Script">
                 <!--                <add name="WebDAV" path="*" verb="PROPFIND,PROPPATCH,MKCOL,PUT,COPY,DELETE,MOVE,LOCK,UNLOCK" modules="WebDAVModule" resourceType="Unspecified" requireAccess="None" /> -->

--- a/test/ServerComparison.FunctionalTests/NtlmAuthentation.config
+++ b/test/ServerComparison.FunctionalTests/NtlmAuthentation.config
@@ -118,7 +118,7 @@
             </sectionGroup>
             <section name="applicationInitialization" allowDefinition="MachineToApplication" overrideModeDefault="Allow" />
             <section name="webSocket" overrideModeDefault="Deny" />
-            <section name="httpPlatform" overrideModeDefault="Allow" />
+            <section name="aspNetCore" overrideModeDefault="Allow" />
         </sectionGroup>
     </configSections>
 
@@ -253,7 +253,7 @@
             <add name="ManagedEngine64" image="%windir%\Microsoft.NET\Framework64\v2.0.50727\webengine.dll" preCondition="integratedMode,runtimeVersionv2.0,bitness64" />
             <add name="ManagedEngineV4.0_32bit" image="%windir%\Microsoft.NET\Framework\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness32" />
             <add name="ManagedEngineV4.0_64bit" image="%windir%\Microsoft.NET\Framework64\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness64" />
-            <add name="httpPlatformHandler" image="%SystemRoot%\system32\inetsrv\httpPlatformHandler.dll" />
+            <add name="AspNetCoreModule" image="%SystemRoot%\system32\inetsrv\aspnetcore.dll" />
         </globalModules>
 
         <httpCompression directory="%TEMP%\iisexpress\IIS Temporary Compressed Files">
@@ -928,7 +928,7 @@
                 <add name="UrlRoutingModule-4.0" type="System.Web.Routing.UrlRoutingModule" preCondition="managedHandler,runtimeVersionv4.0" />
                 <add name="ScriptModule-4.0" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
                 <add name="ServiceModel" type="System.ServiceModel.Activation.HttpModule, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="managedHandler,runtimeVersionv2.0" />
-                <add name="httpPlatformHandler" />
+                <add name="AspNetCoreModule" />
             </modules>
             <handlers accessPolicy="Read, Script">
                 <!--                <add name="WebDAV" path="*" verb="PROPFIND,PROPPATCH,MKCOL,PUT,COPY,DELETE,MOVE,LOCK,UNLOCK" modules="WebDAVModule" resourceType="Unspecified" requireAccess="None" /> -->

--- a/test/ServerComparison.FunctionalTests/ResponseTests.cs
+++ b/test/ServerComparison.FunctionalTests/ResponseTests.cs
@@ -53,15 +53,15 @@ namespace ServerComparison.FunctionalTests
             return ResponseFormats(serverType, runtimeFlavor, architecture, applicationBaseUrl, CheckConnectionCloseAsync);
         }
 
-        // [ConditionalTheory]
-        // [OSSkipCondition(OperatingSystems.Linux)]
-        // [OSSkipCondition(OperatingSystems.MacOSX)]
-        // // [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, "http://localhost:5078/")] // https://github.com/aspnet/IISIntegration/issues/7
-        // [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x86, "http://localhost:5079/")]
-        // public Task ResponseFormats_Windows_Chunked(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, string applicationBaseUrl)
-        // {
-        //     return ResponseFormats(serverType, runtimeFlavor, architecture, applicationBaseUrl, CheckChunkedAsync);
-        // }
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, "http://localhost:5078/")]
+        [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, "http://localhost:5079/")]
+        public Task ResponseFormats_Windows_Chunked(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, string applicationBaseUrl)
+        {
+            return ResponseFormats(serverType, runtimeFlavor, architecture, applicationBaseUrl, CheckChunkedAsync);
+        }
 
         [Theory]
         [InlineData(ServerType.Kestrel, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, "http://localhost:5080/")]
@@ -73,7 +73,7 @@ namespace ServerComparison.FunctionalTests
         [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
-        // [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, "http://localhost:5081/")] // https://github.com/aspnet/IISIntegration/issues/7
+        [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, "http://localhost:5081/")]
         [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, "http://localhost:5082/")]
         public Task ResponseFormats_Windows_ManuallyChunk(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, string applicationBaseUrl)
         {

--- a/test/ServerComparison.TestSites/Program.cs
+++ b/test/ServerComparison.TestSites/Program.cs
@@ -10,9 +10,9 @@ namespace ServerComparison.TestSites
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
-                .UseServer   ("Microsoft.AspNetCore.Server.Kestrel")
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
                 .UseDefaultConfiguration(args)
-                .UseIISPlatformHandlerUrl()
+                .UseIISUrl()
                 .UseStartup("ServerComparison.TestSites")
                 .Build();
 

--- a/test/ServerComparison.TestSites/StartupNtlmAuthentication.cs
+++ b/test/ServerComparison.TestSites/StartupNtlmAuthentication.cs
@@ -57,7 +57,7 @@ namespace ServerComparison.TestSites
             }
             else
             {
-                app.UseIISPlatformHandler();
+                app.UseIIS();
             }
 
             app.Use((context, next) => 

--- a/test/ServerComparison.TestSites/project.json
+++ b/test/ServerComparison.TestSites/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0-*",

--- a/test/ServerComparison.TestSites/wwwroot/web.config
+++ b/test/ServerComparison.TestSites/wwwroot/web.config
@@ -1,8 +1,8 @@
 <configuration>
   <system.webServer>
-    <httpPlatform  forwardWindowsAuthToken="true" processPath="..\ServerComparison.TestSites.exe" stdoutLogEnabled="false" stdoutLogFile="..\logs\stdout.log" startupTimeLimit="3600" />
+    <aspNetCore  forwardWindowsAuthToken="true" processPath="..\ServerComparison.TestSites.exe" stdoutLogEnabled="false" stdoutLogFile="..\logs\stdout.log" startupTimeLimit="3600" />
     <handlers>
-      <add name="httpplatformhandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
     </handlers>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
Depends on https://github.com/aspnet/IISIntegration/pull/96
Includes https://github.com/aspnet/ServerTests/pull/15.

Note merging this will require installing AspNetCoreModule on all test machines.

@moozzyk @muratg 