### PR TITLE
Use UseServer() instead of UseKestrel() to allow override in tests

### DIFF
--- a/test/ServerComparison.TestSites/Program.cs
+++ b/test/ServerComparison.TestSites/Program.cs
@@ -10,7 +10,9 @@ namespace ServerComparison.TestSites
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
-                .UseKestrel()
+                // We set the server by name before default args so that command line arguments can override it.
+                // This is used to allow deployers to choose the server for testing.
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
                 .UseDefaultHostingConfiguration(args)
                 .UseIISIntegration()
                 .UseStartup("ServerComparison.TestSites")


### PR DESCRIPTION
This is needed to fix the build. Explanation is in the comments.

Review: @mikeharder @Tratcher 
Approval: @Eilon @DamianEdwards 