### PR TITLE
Add Configuration.EnvironmentVariables

### DIFF
--- a/test/ServerComparison.TestSites/project.json
+++ b/test/ServerComparison.TestSites/project.json
@@ -6,6 +6,7 @@
     "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0-*",
     "Microsoft.Extensions.Configuration.CommandLine": "1.0.0-*",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",
     "Microsoft.Extensions.Logging.Console": "1.0.0-*",
     "Microsoft.Net.Http.Headers": "1.0.0-*"


### PR DESCRIPTION
CC @JunTaoLuo 

Reacting to Hosting no longer passing along Microsoft.Extensions.Configuration.EnvironmentVariables as of [here](https://github.com/aspnet/Hosting/commit/e505ecbc2176cc35b6fb0e3fd51fc7bf4c484cf4#diff-d57e9b9423ed4dca1dde6a721b9e47a4L25).

@Eilon this fixes the CoreCLR gate, so I'll be asking for ex-post-facto ask-mode approval.