### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/ServerComparison.FunctionalTests/NtlmAuthenticationTest.cs
+++ b/test/ServerComparison.FunctionalTests/NtlmAuthenticationTest.cs
@@ -1,6 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-#if NET451
+#if NET452
 
 using System;
 using System.Net;

--- a/test/ServerComparison.FunctionalTests/ServerComparison.FunctionalTests.csproj
+++ b/test/ServerComparison.FunctionalTests/ServerComparison.FunctionalTests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/test/ServerComparison.TestSites/ServerComparison.TestSites.csproj
+++ b/test/ServerComparison.TestSites/ServerComparison.TestSites.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <!-- TODO remove when https://github.com/dotnet/sdk/issues/396 is resolved -->
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows