### PR TITLE
Use .NET 4.5.2 target framework when deploying test sites

### DIFF
--- a/test/ServerComparison.FunctionalTests/HelloWorldTest.cs
+++ b/test/ServerComparison.FunctionalTests/HelloWorldTest.cs
@@ -74,7 +74,7 @@ namespace ServerComparison.FunctionalTests
                     EnvironmentName = "HelloWorld", // Will pick the Start class named 'StartupHelloWorld',
                     ServerConfigTemplateContent = Helpers.GetConfigContent(serverType, "Http.config", "nginx.conf"),
                     SiteName = "HttpTestSite", // This is configured in the Http.config
-                    TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net451" : "netcoreapp1.1",
+                    TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net452" : "netcoreapp1.1",
                     ApplicationType = applicationType
                 };
 

--- a/test/ServerComparison.FunctionalTests/NtlmAuthenticationTest.cs
+++ b/test/ServerComparison.FunctionalTests/NtlmAuthenticationTest.cs
@@ -40,7 +40,8 @@ namespace ServerComparison.FunctionalTests
                     EnvironmentName = "NtlmAuthentication", // Will pick the Start class named 'StartupNtlmAuthentication'
                     ServerConfigTemplateContent = Helpers.GetConfigContent(serverType, "NtlmAuthentication.config", nginxConfig: null),
                     SiteName = "NtlmAuthenticationTestSite", // This is configured in the NtlmAuthentication.config
-                    ApplicationType = applicationType
+                    ApplicationType = applicationType,
+                    TargetFramework = "net452",
                 };
 
                 using (var deployer = ApplicationDeployerFactory.Create(deploymentParameters, logger))

--- a/test/ServerComparison.FunctionalTests/ResponseCompressionTests.cs
+++ b/test/ServerComparison.FunctionalTests/ResponseCompressionTests.cs
@@ -132,7 +132,7 @@ namespace ServerComparison.FunctionalTests
                         hostCompression ? "http.config" : "NoCompression.config",
                         hostCompression ? "nginx.conf" : "NoCompression.conf"),
                     SiteName = "HttpTestSite", // This is configured in the Http.config
-                    TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net451" : "netcoreapp1.1",
+                    TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net452" : "netcoreapp1.1",
                     ApplicationType = applicationType
                 };
 

--- a/test/ServerComparison.FunctionalTests/ResponseTests.cs
+++ b/test/ServerComparison.FunctionalTests/ResponseTests.cs
@@ -167,7 +167,7 @@ namespace ServerComparison.FunctionalTests
                     EnvironmentName = "Responses",
                     ServerConfigTemplateContent = Helpers.GetConfigContent(serverType, "Http.config", "nginx.conf"),
                     SiteName = "HttpTestSite", // This is configured in the Http.config
-                    TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net451" : "netcoreapp1.1",
+                    TargetFramework = runtimeFlavor == RuntimeFlavor.Clr ? "net452" : "netcoreapp1.1",
                     ApplicationType = applicationType
                 };
 


### PR DESCRIPTION
- follow-up to 0527786
- sites are also built for .NET 4.5.2 in desktop runs