### PR TITLE
Fix disabled NTLM tests

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,6 +6,7 @@
     <AspNetCoreModuleVersion>1.0.0-*</AspNetCoreModuleVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <SystemNetHttpVersion>4.3.1</SystemNetHttpVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <XunitVersion>2.2.0</XunitVersion>
   </PropertyGroup>

--- a/test/ServerComparison.FunctionalTests/NtlmAuthenticationTest.cs
+++ b/test/ServerComparison.FunctionalTests/NtlmAuthenticationTest.cs
@@ -18,7 +18,7 @@ namespace ServerComparison.FunctionalTests
     // Uses ports ranging 5050 - 5060.
     public class NtlmAuthenticationTests
     {
-        [ConditionalTheory(Skip="Failures to net46 conversion"), Trait("ServerComparison.FunctionalTests", "ServerComparison.FunctionalTests")]
+        [ConditionalTheory, Trait("ServerComparison.FunctionalTests", "ServerComparison.FunctionalTests")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         // TODO: https://github.com/aspnet/IISIntegration/issues/1

--- a/test/ServerComparison.FunctionalTests/ServerComparison.FunctionalTests.csproj
+++ b/test/ServerComparison.FunctionalTests/ServerComparison.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\common.props" />
 
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Dotnet.PlatformAbstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>


### PR DESCRIPTION
#61 
System.Net.Http 4.3.0 does not have the same behavior on .NET 4.6, use 4.3.1 instead.