### PR TITLE
Simplify test TFMs

### DIFF
--- a/test/ServerComparison.FunctionalTests/HelloWorldTest.cs
+++ b/test/ServerComparison.FunctionalTests/HelloWorldTest.cs
@@ -20,17 +20,9 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
-        [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x86, ApplicationType.Portable, Skip = "Tests disabled on x86 because of https://github.com/aspnet/Hosting/issues/601")]
-        [InlineData(ServerType.Kestrel, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)]
-        public Task HelloWorld_Windows_CLR(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
-        {
-            return HelloWorld(serverType, runtimeFlavor, architecture, applicationType);
-        }
-
-        [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
+        [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x86, ApplicationType.Portable, Skip = "Tests disabled on x86 because of https://github.com/aspnet/Hosting/issues/601")]
         [InlineData(ServerType.WebListener, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Portable)]
         [InlineData(ServerType.WebListener, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Standalone)]
         public Task HelloWorld_HttpSys(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
@@ -39,7 +31,6 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CLR)] 
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.IISExpress, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Standalone, HostingModel.InProcess)]
@@ -50,6 +41,15 @@ namespace ServerComparison.FunctionalTests
         public Task HelloWorld_IISExpress(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType, HostingModel hostingModel)
         {
             return HelloWorld(serverType, runtimeFlavor, architecture, applicationType, hostingModel: hostingModel);
+        }
+
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [InlineData(ServerType.Kestrel, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)]
+        public Task HelloWorld_Kestrel_Clr(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
+        {
+            return HelloWorld(serverType, runtimeFlavor, architecture, applicationType);
         }
 
         [Theory]

--- a/test/ServerComparison.FunctionalTests/Helpers.cs
+++ b/test/ServerComparison.FunctionalTests/Helpers.cs
@@ -50,12 +50,7 @@ namespace ServerComparison.FunctionalTests
         {
             if (runtimeFlavor == RuntimeFlavor.Clr)
             {
-#if NET461
                 return "net461";
-#elif NETCOREAPP2_0 || NETCOREAPP2_1
-#else
-#error Tests targeting CLR must be compiled only on desktop.
-#endif
             }
             else if (runtimeFlavor == RuntimeFlavor.CoreClr)
             {
@@ -68,7 +63,7 @@ namespace ServerComparison.FunctionalTests
 #endif
             }
 
-            throw new ArgumentException($"Unknown RuntimeFlavor '{runtimeFlavor}");
+            throw new ArgumentException($"Unknown RuntimeFlavor '{runtimeFlavor}'");
         }
     }
 }

--- a/test/ServerComparison.FunctionalTests/NtlmAuthenticationTest.cs
+++ b/test/ServerComparison.FunctionalTests/NtlmAuthenticationTest.cs
@@ -1,6 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-#if NET461 // https://github.com/aspnet/ServerTests/issues/82
 
 using System.Net;
 using System.Net.Http;
@@ -22,7 +21,6 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [Trait("ServerComparison.FunctionalTests", "ServerComparison.FunctionalTests")]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.IISExpress, RuntimeFlavor.CoreClr, "netcoreapp2.0", RuntimeArchitecture.x86, ApplicationType.Portable, Skip = "Tests disabled on x86 because of https://github.com/aspnet/Hosting/issues/601")]
@@ -118,7 +116,3 @@ namespace ServerComparison.FunctionalTests
         }
     }
 }
-#elif NETCOREAPP2_0 || NETCOREAPP2_1
-#else
-#error target frameworks need to be updated
-#endif

--- a/test/ServerComparison.FunctionalTests/ResponseCompressionTests.cs
+++ b/test/ServerComparison.FunctionalTests/ResponseCompressionTests.cs
@@ -31,7 +31,8 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable, Skip = "Websdk issue with full framework publish. See https://github.com/aspnet/websdk/pull/322")]
         [InlineData(ServerType.IISExpress, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Portable)]
         [InlineData(ServerType.IISExpress, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Standalone)]
@@ -41,7 +42,8 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)]
         public Task ResponseCompression_Windows_NoCompression(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
         {
@@ -74,7 +76,6 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalFact(Skip ="Websdk issue with full framework publish. See https://github.com/aspnet/websdk/pull/322")]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task ResponseCompression_IISExpress_HostCompression_CLR()
@@ -92,7 +93,8 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task ResponseCompression_Windows_AppCompression_CLR()
         {
             return ResponseCompression(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, CheckAppCompressionAsync, ApplicationType.Portable, hostCompression: false);
@@ -132,7 +134,6 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalFact(Skip = "Websdk issue with full framework publish. See https://github.com/aspnet/websdk/pull/322")]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         public Task ResponseCompression_Windows_AppAndHostCompression_CLR()

--- a/test/ServerComparison.FunctionalTests/ResponseTests.cs
+++ b/test/ServerComparison.FunctionalTests/ResponseTests.cs
@@ -25,7 +25,8 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable, Skip = "Websdk issue with full framework publish. See https://github.com/aspnet/websdk/pull/322")]
         [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)]
         public Task ResponseFormats_Windows_ContentLength(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
@@ -51,7 +52,8 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)]
         // IIS will remove the "Connection: close" header https://github.com/aspnet/IISIntegration/issues/7
         public Task ResponseFormats_Windows_Http10ConnectionClose(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
@@ -61,7 +63,8 @@ namespace ServerComparison.FunctionalTests
 
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)] // https://github.com/aspnet/WebListener/issues/259
         // IIS will remove the "Connection: close" header https://github.com/aspnet/IISIntegration/issues/7
         public Task ResponseFormats_Windows_Http11ConnectionClose(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
@@ -86,7 +89,8 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable, Skip = "Websdk issue with full framework publish. See https://github.com/aspnet/websdk/pull/322")]
         [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)]
         public Task ResponseFormats_Windows_Chunked(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
@@ -112,7 +116,8 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable, Skip = "Websdk issue with full framework publish. See https://github.com/aspnet/websdk/pull/322")]
         [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)]
         public Task ResponseFormats_Windows_ManuallyChunk(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)
@@ -138,7 +143,8 @@ namespace ServerComparison.FunctionalTests
         }
 
         [ConditionalTheory]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR)]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
         // [InlineData(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)] // https://github.com/aspnet/IISIntegration/issues/7
         [InlineData(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable)]
         public Task ResponseFormats_Windows_ManuallyChunkAndClose(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, ApplicationType applicationType)

--- a/test/ServerComparison.FunctionalTests/ServerComparison.FunctionalTests.csproj
+++ b/test/ServerComparison.FunctionalTests/ServerComparison.FunctionalTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
+    <!-- Use 2.1 to run the tests. The tests will select their own TFMs for the test application when publishing -->
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 #82
NetCoreApp2.1 now has a HttpClient implementation with consistent behavior across platforms. This allows us to use the same client to run all of the tests. I've changed the primary test project to only target netcoreapp2.1. The actual tests select their own TFMs when publishing the test site.