### PR TITLE
Enable x86 test

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,7 +10,7 @@
     <MicrosoftAspNetCoreServerHttpSysPackageVersion>2.2.0-preview1-34255</MicrosoftAspNetCoreServerHttpSysPackageVersion>
     <MicrosoftAspNetCoreServerIISIntegrationPackageVersion>2.2.0-preview1-34255</MicrosoftAspNetCoreServerIISIntegrationPackageVersion>
     <MicrosoftAspNetCoreServerIISPackageVersion>2.2.0-preview1-34255</MicrosoftAspNetCoreServerIISPackageVersion>
-    <MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>0.6.0-preview1-34255</MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>
+    <MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>0.6.0-a-preview1-tratcher-x86-17042</MicrosoftAspNetCoreServerIntegrationTestingPackageVersion>
     <MicrosoftAspNetCoreServerKestrelPackageVersion>2.2.0-preview1-34255</MicrosoftAspNetCoreServerKestrelPackageVersion>
     <MicrosoftAspNetCoreWebUtilitiesPackageVersion>2.2.0-preview1-34255</MicrosoftAspNetCoreWebUtilitiesPackageVersion>
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.2.0-preview1-34255</MicrosoftExtensionsConfigurationCommandLinePackageVersion>

--- a/build/repo.props
+++ b/build/repo.props
@@ -11,8 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp20PackageVersion)" />
-    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" />
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp22PackageVersion)" />
+    <DotNetCoreRuntime Condition="'$(OS)' == 'Windows_NT'" Include="$(MicrosoftNETCoreApp22PackageVersion)" Arch="x86" />
   </ItemGroup>
 </Project>

--- a/test/ServerComparison.FunctionalTests/HelloWorldTest.cs
+++ b/test/ServerComparison.FunctionalTests/HelloWorldTest.cs
@@ -24,7 +24,8 @@ namespace ServerComparison.FunctionalTests
                 .WithTfms(Tfm.NetCoreApp22, Tfm.Net461)
                 .WithAllApplicationTypes()
                 .WithAllAncmVersions()
-                .WithAllHostingModels();
+                .WithAllHostingModels()
+                .WithAllArchitectures();
 
         [ConditionalTheory]
         [MemberData(nameof(TestVariants))]
@@ -56,7 +57,14 @@ namespace ServerComparison.FunctionalTests
                     var responseText = await response.Content.ReadAsStringAsync();
                     try
                     {
-                        Assert.Equal("Hello World", responseText);
+                        if (variant.Architecture == RuntimeArchitecture.x64)
+                        {
+                            Assert.Equal("Hello World X64", responseText);
+                        }
+                        else
+                        {
+                            Assert.Equal("Hello World X86", responseText);
+                        }
                     }
                     catch (XunitException)
                     {

--- a/test/ServerComparison.TestSites/StartupHelloWorld.cs
+++ b/test/ServerComparison.TestSites/StartupHelloWorld.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,7 @@ namespace ServerComparison.TestSites
         {
             app.Run(ctx =>
             {
-                return ctx.Response.WriteAsync("Hello World");
+                return ctx.Response.WriteAsync("Hello World " + RuntimeInformation.ProcessArchitecture);
             });
         }
     }


### PR DESCRIPTION
In reaction to https://github.com/aspnet/Hosting/pull/1429, https://github.com/aspnet/Hosting/issues/949.

Install the runtime and the SDK and enable the test variations. One remaining issue (https://github.com/aspnet/Hosting/issues/1428) with net461.