### PR TITLE
[automated] Infrastructure updates for release/2.2

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <!-- These properties are use by the automation that updates dependencies.props -->
     <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
+    <LineupPackageVersion>2.2.0-*</LineupPackageVersion>
     <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</LineupPackageRestoreSource>
   </PropertyGroup>
 

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
-  "channel": "dev"
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/release/2.2/tools/korebuild.schema.json",
+  "channel": "release/2.2"
 }


### PR DESCRIPTION
Part of https://github.com/aspnet/Home/issues/3278.
This should update lineups, korebuild config, and CI devs to use the release/2.2 channel.